### PR TITLE
Fix History Heuristic bug for En Passant and cap history score

### DIFF
--- a/diff.txt
+++ b/diff.txt
@@ -1,0 +1,65 @@
+diff --git a/src/shared/chessAI.js b/src/shared/chessAI.js
+index e2e0e29..b012f67 100644
+--- a/src/shared/chessAI.js
++++ b/src/shared/chessAI.js
+@@ -267,7 +267,12 @@ class ChessAI {
+
+             // History Heuristic: Update score for quiet moves
+             const toPiece = chessGame.board[nextMove.to.row][nextMove.to.col];
+-            if (!toPiece) {
++            const isEnPassant = chessGame.enPassantTarget &&
++                                chessGame.enPassantTarget.row === nextMove.to.row &&
++                                chessGame.enPassantTarget.col === nextMove.to.col &&
++                                chessGame.board[nextMove.from.row][nextMove.from.col]?.type === 'pawn';
++
++            if (!toPiece && !isEnPassant) {
+                 const fromIdx = nextMove.from.row * 8 + nextMove.from.col;
+                 const toIdx = nextMove.to.row * 8 + nextMove.to.col;
+                 this.historyTable[fromIdx][toIdx] += depth * depth;
+@@ -304,7 +309,12 @@ class ChessAI {
+
+             // History Heuristic: Update score for quiet moves
+             const toPiece = chessGame.board[nextMove.to.row][nextMove.to.col];
+-            if (!toPiece) {
++            const isEnPassant = chessGame.enPassantTarget &&
++                                chessGame.enPassantTarget.row === nextMove.to.row &&
++                                chessGame.enPassantTarget.col === nextMove.to.col &&
++                                chessGame.board[nextMove.from.row][nextMove.from.col]?.type === 'pawn';
++
++            if (!toPiece && !isEnPassant) {
+                 const fromIdx = nextMove.from.row * 8 + nextMove.from.col;
+                 const toIdx = nextMove.to.row * 8 + nextMove.to.col;
+                 this.historyTable[fromIdx][toIdx] += depth * depth;
+@@ -646,8 +656,16 @@ class ChessAI {
+     const toPiece = chessGame.board[move.to.row][move.to.col];
+
+     // 2. Captures (MVV-LVA)
++    const isEnPassant = chessGame.enPassantTarget &&
++                        chessGame.enPassantTarget.row === move.to.row &&
++                        chessGame.enPassantTarget.col === move.to.col &&
++                        fromPiece && fromPiece.type === 'pawn';
++
+     if (toPiece) {
+       score = 10 * this.pieceValues[toPiece.type] - this.pieceValues[fromPiece.type] + 1000;
++    } else if (isEnPassant) {
++      // En Passant capture: target is a pawn
++      score = 10 * this.pieceValues['pawn'] - this.pieceValues['pawn'] + 1000;
+     }
+
+     // 3. Killer Moves
+@@ -662,10 +680,13 @@ class ChessAI {
+     }
+
+     // 5. History Heuristic
+-    if (this.historyTable) {
++    if (!toPiece && !isEnPassant && this.historyTable) {
+         const fromIdx = move.from.row * 8 + move.from.col;
+         const toIdx = move.to.row * 8 + move.to.col;
+-        score += this.historyTable[fromIdx][toIdx];
++
++        // Cap history score to ensure captures and killer moves take precedence
++        const historyScore = Math.min(this.historyTable[fromIdx][toIdx], 700);
++        score += historyScore;
+     }
+
+     return score;

--- a/src/shared/chessAI.js
+++ b/src/shared/chessAI.js
@@ -267,7 +267,12 @@ class ChessAI {
 
             // History Heuristic: Update score for quiet moves
             const toPiece = chessGame.board[nextMove.to.row][nextMove.to.col];
-            if (!toPiece) {
+            const isEnPassant = chessGame.enPassantTarget &&
+                                chessGame.enPassantTarget.row === nextMove.to.row &&
+                                chessGame.enPassantTarget.col === nextMove.to.col &&
+                                chessGame.board[nextMove.from.row][nextMove.from.col]?.type === 'pawn';
+
+            if (!toPiece && !isEnPassant) {
                 const fromIdx = nextMove.from.row * 8 + nextMove.from.col;
                 const toIdx = nextMove.to.row * 8 + nextMove.to.col;
                 this.historyTable[fromIdx][toIdx] += depth * depth;
@@ -304,7 +309,12 @@ class ChessAI {
 
             // History Heuristic: Update score for quiet moves
             const toPiece = chessGame.board[nextMove.to.row][nextMove.to.col];
-            if (!toPiece) {
+            const isEnPassant = chessGame.enPassantTarget &&
+                                chessGame.enPassantTarget.row === nextMove.to.row &&
+                                chessGame.enPassantTarget.col === nextMove.to.col &&
+                                chessGame.board[nextMove.from.row][nextMove.from.col]?.type === 'pawn';
+
+            if (!toPiece && !isEnPassant) {
                 const fromIdx = nextMove.from.row * 8 + nextMove.from.col;
                 const toIdx = nextMove.to.row * 8 + nextMove.to.col;
                 this.historyTable[fromIdx][toIdx] += depth * depth;
@@ -646,8 +656,16 @@ class ChessAI {
     const toPiece = chessGame.board[move.to.row][move.to.col];
 
     // 2. Captures (MVV-LVA)
+    const isEnPassant = chessGame.enPassantTarget &&
+                        chessGame.enPassantTarget.row === move.to.row &&
+                        chessGame.enPassantTarget.col === move.to.col &&
+                        fromPiece && fromPiece.type === 'pawn';
+
     if (toPiece) {
       score = 10 * this.pieceValues[toPiece.type] - this.pieceValues[fromPiece.type] + 1000;
+    } else if (isEnPassant) {
+      // En Passant capture: target is a pawn
+      score = 10 * this.pieceValues['pawn'] - this.pieceValues['pawn'] + 1000;
     }
 
     // 3. Killer Moves
@@ -662,10 +680,13 @@ class ChessAI {
     }
 
     // 5. History Heuristic
-    if (this.historyTable) {
+    if (!toPiece && !isEnPassant && this.historyTable) {
         const fromIdx = move.from.row * 8 + move.from.col;
         const toIdx = move.to.row * 8 + move.to.col;
-        score += this.historyTable[fromIdx][toIdx];
+
+        // Cap history score to ensure captures and killer moves take precedence
+        const historyScore = Math.min(this.historyTable[fromIdx][toIdx], 700);
+        score += historyScore;
     }
 
     return score;


### PR DESCRIPTION
- Identified and fixed a bug where En Passant captures were treated as quiet moves by the History Heuristic logic because the target square is initially empty.
- Handled `isEnPassant` boolean check in `minimax` to avoid updating `historyTable` for En Passants.
- Handled `isEnPassant` capture bonus in `scoreMove` alongside normal MVV-LVA logic.
- Implemented a score cap for the History Heuristic inside `scoreMove` to ensure it continues to act as a secondary ordering signal and does not improperly out-prioritize captures or killer moves.

---
*PR created automatically by Jules for task [16728371652925492194](https://jules.google.com/task/16728371652925492194) started by @segin*